### PR TITLE
Fix lodash dependency and ViceLauncher configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 	"dependencies": {
 		"await-notify": "1.0.1",
 		"fast-xml-parser": "3.16.0",
+		"lodash": "^4.17.19",
 		"unique-filename": "^1.1.1",
 		"vscode-debugadapter": "^1.39.1",
 		"vscode-languageclient": "^6.1.1",

--- a/src/vice/viceLauncher.ts
+++ b/src/vice/viceLauncher.ts
@@ -1,7 +1,9 @@
+import * as vscode from 'vscode';
+import { existsSync } from 'fs';
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import { EventEmitter } from 'events';
 import { changeExtension } from '../helpers/pathHelper';
-
+import { getConfig } from '../helpers/extension';
 
 export const ViceLauncherEvent = {
 	closed: 'closed'
@@ -16,7 +18,12 @@ export class ViceLauncher extends EventEmitter {
 			changeExtension(program, '.prg')
 		];
 
-		this.viceProcess = spawn('x64sc',args, {cwd});
+		let config = getConfig();
+		if(!existsSync(config.viceBin)) {
+			vscode.window.showErrorMessage("Vice not found. Check the extension configuration.");
+		}
+
+		this.viceProcess = spawn(config.viceBin ,args, {cwd});
 
 		this.viceProcess.stdout.on('data', (data) => {
 			console.log(`stdout: ${data}`);

--- a/src/vice/viceLauncher.ts
+++ b/src/vice/viceLauncher.ts
@@ -21,6 +21,8 @@ export class ViceLauncher extends EventEmitter {
 		let config = getConfig();
 		if(!existsSync(config.viceBin)) {
 			vscode.window.showErrorMessage("Vice not found. Check the extension configuration.");
+			this.sendEvent(ViceLauncherEvent.closed);
+			return;
 		}
 
 		this.viceProcess = spawn(config.viceBin ,args, {cwd});


### PR DESCRIPTION
This pull request fixes to issues I noticed:

- Lodash isn't listed as a dependency in ``package.json`` therefore it is missing on new installations. (Issue #15 )
- ViceLauncher completely ignored the extension configuration and called a hard coded binary, which fails on systems where the binary isn't in the PATH variable or named differently.

I tested these changes on Ubuntu 20.04 VSCode Version 1.47.2 (.deb Package not the snapcraft image).